### PR TITLE
[CALCITE-3749] Ignore local.proproperties in RAT, Autostyle checks, a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ nb-configuration.xml
 
 .mvn/wrapper/maven-wrapper.jar
 
-# End .gitignore
+# Local configuration file (sdk path, etc)
+local.properties

--- a/.ratignore
+++ b/.ratignore
@@ -1,3 +1,4 @@
+**/local.properties
 **/.editorconfig
 **/.gitignore
 **/.gitattributes


### PR DESCRIPTION
…nd in .gitignore

JitPack adds local.properties with paths to SDKs, so it should not
participate in license checks.